### PR TITLE
Corrected to reference examples not spec

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,3 @@
-This is the OpenMP 4.0 specification in LaTex format.
-Please see the master file, openmp-4.0.tex, for more information.
+This is the OpenMP 4.0.1 Examples in LaTex format.
+Please see the master file, openmp-examples.tex, for more information.
 


### PR DESCRIPTION
Hi Henry,
   I changed to the README file to reference the Examples.  It said that this was the spec section.
   Could you please pull my master. 
Kent
