### PR TITLE
added minted-based highlighting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Makefile for the OpenMP Examples document in LaTex format. 
+# Makefile for the OpenMP Examples document in LaTex format.
 # For more information, see the master document, openmp-examples.tex.
 
 version=4.0.1ltx
@@ -74,13 +74,14 @@ INTERMEDIATE_FILES=openmp-examples.pdf \
 		openmp-examples.ilg \
 		openmp-examples.ind \
 		openmp-examples.out \
-		openmp-examples.log
+		openmp-examples.log \
+		openmp-examples.pyg
 
 openmp-examples.pdf: $(CHAPTERS) openmp.sty openmp-examples.tex openmp-logo.png
 	rm -f $(INTERMEDIATE_FILES)
-	pdflatex -interaction=batchmode -file-line-error openmp-examples.tex
-	pdflatex -interaction=batchmode -file-line-error openmp-examples.tex
-	pdflatex -interaction=batchmode -file-line-error openmp-examples.tex
+	pdflatex -shell-escape -interaction=batchmode -file-line-error openmp-examples.tex
+	pdflatex -shell-escape -interaction=batchmode -file-line-error openmp-examples.tex
+	pdflatex -shell-escape -interaction=batchmode -file-line-error openmp-examples.tex
 	cp openmp-examples.pdf openmp-examples-${version}.pdf
 
 clean:

--- a/openmp.sty
+++ b/openmp.sty
@@ -420,6 +420,7 @@
 
 \usepackage{color,fancyvrb}  % for \VerbatimInput
 \usepackage{toolbox}         % for \toolboxMakeSplit
+\usepackage{minted}         % for \toolboxMakeSplit
 
 \renewcommand\theFancyVerbLine{\normalfont\footnotesize\sffamily S-\arabic{FancyVerbLine}}
 
@@ -447,21 +448,27 @@
    \textit{Example \ename}
    %\vspace*{-3mm}
 }
+\usemintedstyle{trac}
+\newmintedfile[mintc]{c}{linenos,numbersep=5ex,firstnumber=1,firstline=8,fontsize=\small}
 
 \def\cnexample#1#2{%
    \exampleheader{#1}{#2}
-   \code{\VerbatimInput[numbers=left,numbersep=5ex,firstnumber=1,firstline=8,fontsize=\small]%
+   % \code{\VerbatimInput[numbers=left,numbersep=5ex,firstnumber=1,firstline=8,fontsize=\small]%
+   \par\mintc
    %\code{\VerbatimInput[numbers=left,firstnumber=1,firstline=8,fontsize=\small]%
    %\code{\VerbatimInput[firstline=8,fontsize=\small]%
-      {sources/Example_\cname.c}} 
+   {sources/Example_\cname.c}
 }
+
+\newmintedfile[mintf]{fortran}{linenos,numbersep=5ex,firstnumber=1,firstline=6,fontsize=\small}
 
 \def\fnexample#1#2{%
    \exampleheader{#1}{#2}
-   \code{\VerbatimInput[numbers=left,numbersep=5ex,firstnumber=1,firstline=6,fontsize=\small]%
+   % \code{\VerbatimInput[numbers=left,numbersep=5ex,firstnumber=1,firstline=6,fontsize=\small]%
+   \par\mintf
    %\code{\VerbatimInput[numbers=left,firstnumber=1,firstline=6,fontsize=\small]%
    %\code{\VerbatimInput[firstline=6,fontsize=\small]%
-      {sources/Example_\cname.f}}
+   {sources/Example_\cname.f}
 }
 
 \newcommand\cexample[2]{%


### PR DESCRIPTION
This change adds syntax highlighting for all C and Fortran examples.  Some C++ will be mis-highlighted because it is using a C style rather than a C++ style, but we have no way to differentiate at the moment.

To change the style, just change the `\usemintedstyle` line, any pygments style is accepted.

In order to compile this, [pygments](http://pygments.org/) is required.  On most platforms with python, either `easy_install pygments` or `pip install pygments` will take care of that.