### PR TITLE
Fix computation of fibonacci numbers.

### DIFF
--- a/sources/Example_SIMD.7c.c
+++ b/sources/Example_SIMD.7c.c
@@ -14,7 +14,7 @@ int a[N], b[N], c[N];
 #pragma omp declare simd inbranch
 int fib( int n )
 {
-   if (n <= 2)
+   if (n <= 1)
       return n;
    else {
       return fib(n-1) + fib(n-2);

--- a/sources/Example_SIMD.7f.f
+++ b/sources/Example_SIMD.7f.f
@@ -21,7 +21,7 @@ program fibonacci
    end do
    
    write(*,*) "Done a(", N-1, ") = ", a(N-1)
-                        ! 44  1134903168
+                        ! 44  701408733
 end program
 
 recursive function fib(n) result(r)
@@ -29,7 +29,7 @@ recursive function fib(n) result(r)
    implicit none
    integer  :: n, r
 
-   if (n <= 2) then
+   if (n <= 1) then
       r = n
    else 
       r = fib(n-1) + fib(n-2)


### PR DESCRIPTION
fib(2) is 1 rather than 2, but there is no need to special case it when fib(0) (== 0) and fib(1) (== 1) are already special cased.