### PR TITLE
Make sure sum isn't reduced just within each team, but across teams too.

### DIFF
--- a/sources/Example_teams.3c.c
+++ b/sources/Example_teams.3c.c
@@ -9,7 +9,8 @@ float dotprod(float B[], float C[], int N)
 {
    float sum = 0;
    int i;
-   #pragma omp target teams map(to: B[0:N], C[0:N])
+   #pragma omp target teams map(to: B[0:N], C[0:N]) \
+			    map(tofrom: sum) reduction(+:sum)
    #pragma omp distribute parallel for reduction(+:sum)
    for (i=0; i<N; i++)
       sum += B[i] * C[i];

--- a/sources/Example_teams.3f.f
+++ b/sources/Example_teams.3f.f
@@ -7,7 +7,8 @@ function dotprod(B,C,N) result(sum)
    real    :: B(N), C(N), sum
    integer :: N, i
    sum = 0.0e0
-   !$omp target teams map(to: B, C)
+   !$omp target teams map(to: B, C) map(tofrom: sum) &
+   !$omp& reduction(+:sum)
    !$omp distribute parallel do reduction(+:sum)
       do i = 1,N
          sum = sum + B(i) * C(i)

--- a/sources/Example_teams.4c.c
+++ b/sources/Example_teams.4c.c
@@ -10,8 +10,8 @@ float dotprod(float B[], float C[])
 {
     float sum = 0;
     int i;
-    #pragma omp target map(to: B[0:N], C[0:N])
-    #pragma omp teams num_teams(8) thread_limit(16)
+    #pragma omp target map(to: B[0:N], C[0:N]) map(tofrom: sum)
+    #pragma omp teams num_teams(8) thread_limit(16) reduction(+:sum)
     #pragma omp distribute parallel for reduction(+:sum) \
                 dist_schedule(static, 1024) schedule(static, 64)
     for (i=0; i<N; i++)

--- a/sources/Example_teams.4f.f
+++ b/sources/Example_teams.4f.f
@@ -12,8 +12,8 @@ use arrays
    real    :: sum
    integer :: i
    sum = 0.0e0
-   !$omp target map(to: B, C)
-   !$omp teams num_teams(8) thread_limit(16)
+   !$omp target map(to: B, C) map(tofrom: sum)
+   !$omp teams num_teams(8) thread_limit(16) reduction(+:sum)
    !$omp distribute parallel do reduction(+:sum) &
    !$omp&  dist_schedule(static, 1024) schedule(static, 64)
       do i = 1,N


### PR DESCRIPTION
Make the testcases also OpenMP 4.5 compliant by adding map(tofrom: sum),
otherwise sum is firstprivate on target.
